### PR TITLE
Update plugin.php / Fix 4 deprecated Notice

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -43,7 +43,7 @@ add_action( 'admin_init', 'editor_blocks_redirect' );
 
 // Add custom block category.
 add_filter(
-	'block_categories',
+	'block_categories_all',
 	function( $categories, $post ) {
 		return array_merge(
 			$categories,


### PR DESCRIPTION
Fix for PHP Notice:
PHP Deprecated:  Hook block_categories is deprecated since ver                                                                                                                                                             sion 5.8.0! Use block_categories_all instead.